### PR TITLE
add script to test legend generation

### DIFF
--- a/tests/test-legend.R
+++ b/tests/test-legend.R
@@ -1,0 +1,21 @@
+#!/usr/bin/env R
+
+source("../R/phonR.R")
+load("../data/indoVowels.rda")
+
+colorby <- rep(c("vowel", "subj", "gender"), each=3)
+styleby <- rep(c("vowel", "subj", "gender"), times=3)
+grouping <- c("subj", "gender", NA, "gender", NA, "subj", NA, "subj", "gender")
+
+
+cairo_pdf("test-legend-master.pdf", width=16, height=16, pointsize=12, 
+          family="Charis SIL")
+    par(mfrow=c(3, 3))
+    mapply(FUN=function(cb, sb, gr) {
+        title <- paste0("var.col.by=", cb, ", var.sty.by=", sb, ", group=", gr, collapse="")
+        plotVowels(indo$f1, indo$f2, indo$vowel, group=indo[[gr]], 
+                 var.col.by=indo[[cb]], var.sty.by=indo[[sb]], pretty=TRUE,
+                 plot.tokens=TRUE, plot.means=FALSE, ellipse.line=TRUE, 
+                 legend.kwd='bottomright', main=title)
+        }, colorby, styleby, grouping)
+dev.off()


### PR DESCRIPTION
@djvill this is a pull request from my branch `test-djv-fixes` into your `master` branch.  It doesn't change any of your code, but it adds a new file `tests/test-legend.R` that when run will produce a grid of 9 plots with various settings for `var.col.by`, `var.sty.by`, and `group`.  You can safely merge this and then `git pull` to get a copy of that test script locally so you can run it.  Then have a look at that plot and see if everything looks the way you expect...  to me it looks like the North, West, Southwest, and South plots are still missing some legend entries (although most of the others look either the same as or better than when I run the test script with my current master branch, so you do appear to have fixed some of the bugginess -- thanks!).
